### PR TITLE
OpenRefine defaults to guessCellValueTypes=False since 2.6

### DIFF
--- a/google/refine/refine.py
+++ b/google/refine/refine.py
@@ -216,7 +216,7 @@ class Refine:
                     skip_data_lines=0,
                     limit=-1,
                     store_blank_rows=True,
-                    guess_cell_value_types=True,
+                    guess_cell_value_types=False,
                     process_quotes=True,
                     store_blank_cells_as_nulls=True,
                     include_file_sources=False,


### PR DESCRIPTION
the change was introduced with commit https://github.com/OpenRefine/OpenRefine/commit/b3f5fada9594cc694b0ae4bef5ad9bec71cce3a1 I guess