### PR TITLE
added method for templating export

### DIFF
--- a/google/refine/refine.py
+++ b/google/refine/refine.py
@@ -433,6 +433,18 @@ class RefineProject:
                export_format)
         return self.do_raw(url, data={'format': export_format})
 
+    def export_templating(self, engine='', prefix='',
+                          template='', rowSeparator='\n', suffix=''):
+        """Return a fileobject of a project's data in templating mode."""
+        url = ('export-rows/' + urllib.quote(self.project_name()) + '.' +
+               'txt')
+        return self.do_raw(url, data={'format': 'template',
+                                      'template': template,
+                                      'engine': engine,
+                                      'prefix': prefix,
+                                      'suffix': suffix,
+                                      'separator': rowSeparator})
+
     def export_rows(self, **kwargs):
         """Return an iterable of parsed rows of a project's data."""
         return csv.reader(self.export(**kwargs), dialect='excel-tab')


### PR DESCRIPTION
The OpenRefine [Templating](https://github.com/OpenRefine/OpenRefine/wiki/Export-As-YAML) supports exporting data in any text format (i.e. to construct JSON or XML). The graphical user interface offers four input fields:

1. prefix
2. row template (supports GREL inside two curly brackets, e.g. `{{jsonize(cells["name"].value)}}`)
3. row separator
4. suffix

The proposed new method adds the templating feature to the client:
`export_templating(self, engine='', prefix='', template='', rowSeparator='\n', suffix='')`

## example

in:
``` python
from google.refine import refine

server1 = refine.Refine('http://localhost:3333')

project1 = server1.new_project(project_file='tests/data/duplicates.csv')

data = project1.export_templating(
    prefix='''{ "events" : [
''',
    template='''    { "name" : {{jsonize(cells["name"].value)}}, "purchase" : {{jsonize(cells["purchase"].value)}} }''',
    rowSeparator=''',
''',
    suffix='''
] }''')

print(data.read())
```

out:
``` json
{ "events" : [
    { "name" : "Danny Baron", "purchase" : "TV" },
    { "name" : "Melanie White", "purchase" : "iPhone" },
    { "name" : "D. Baron", "purchase" : "Winter jacket" },
    { "name" : "Ben Tyler", "purchase" : "Flashlight" },
    { "name" : "Arthur Duff", "purchase" : "Dining table" },
    { "name" : "Daniel Baron", "purchase" : "Bike" },
    { "name" : "Jean Griffith", "purchase" : "Power drill" },
    { "name" : "Melanie White", "purchase" : "iPad" },
    { "name" : "Ben Morisson", "purchase" : "Amplifier" },
    { "name" : "Arthur Duff", "purchase" : "Night table" }
] }
```